### PR TITLE
Add price_quantifier property to ErpDocumentItemDTO

### DIFF
--- a/src/DTOs/ErpDocumentItemDTO.php
+++ b/src/DTOs/ErpDocumentItemDTO.php
@@ -14,6 +14,7 @@ class ErpDocumentItemDTO extends Data
         public string|null         $line_item_number = null,
         public string|null         $name = null,
         public float|null          $quantity = null,
+        public string|null         $price_quantifier = null,
         public ProductDTO|null     $product = null,
         public Carbon|null         $valid_until = null,
         public Carbon|null         $delivery_date = null,

--- a/src/DTOs/ErpDocumentItemDTO.php
+++ b/src/DTOs/ErpDocumentItemDTO.php
@@ -14,7 +14,7 @@ class ErpDocumentItemDTO extends Data
         public string|null         $line_item_number = null,
         public string|null         $name = null,
         public float|null          $quantity = null,
-        public string|null         $price_quantifier = null,
+        public string|null         $quantifier = null,
         public ProductDTO|null     $product = null,
         public Carbon|null         $valid_until = null,
         public Carbon|null         $delivery_date = null,

--- a/tests/ErpDocumentItemDTOTest.php
+++ b/tests/ErpDocumentItemDTOTest.php
@@ -84,24 +84,24 @@ class ErpDocumentItemDTOTest extends TestCase
         $this->assertEquals('array|string|null', (string) $reflection->getReturnType());
     }
     
-    public function test_price_quantifier_property_can_be_set_and_retrieved()
+    public function test_quantifier_property_can_be_set_and_retrieved()
     {
-        $dto = new ErpDocumentItemDTO(price_quantifier: 'per_unit');
+        $dto = new ErpDocumentItemDTO(quantifier: 'per_unit');
         
-        $this->assertEquals('per_unit', $dto->price_quantifier);
+        $this->assertEquals('per_unit', $dto->quantifier);
     }
     
-    public function test_price_quantifier_property_defaults_to_null()
+    public function test_quantifier_property_defaults_to_null()
     {
         $dto = new ErpDocumentItemDTO();
         
-        $this->assertNull($dto->price_quantifier);
+        $this->assertNull($dto->quantifier);
     }
     
-    public function test_price_quantifier_property_accepts_null_value()
+    public function test_quantifier_property_accepts_null_value()
     {
-        $dto = new ErpDocumentItemDTO(price_quantifier: null);
+        $dto = new ErpDocumentItemDTO(quantifier: null);
         
-        $this->assertNull($dto->price_quantifier);
+        $this->assertNull($dto->quantifier);
     }
 }

--- a/tests/ErpDocumentItemDTOTest.php
+++ b/tests/ErpDocumentItemDTOTest.php
@@ -83,4 +83,25 @@ class ErpDocumentItemDTOTest extends TestCase
         $this->assertEquals('getCustom', $reflection->getName());
         $this->assertEquals('array|string|null', (string) $reflection->getReturnType());
     }
+    
+    public function test_price_quantifier_property_can_be_set_and_retrieved()
+    {
+        $dto = new ErpDocumentItemDTO(price_quantifier: 'per_unit');
+        
+        $this->assertEquals('per_unit', $dto->price_quantifier);
+    }
+    
+    public function test_price_quantifier_property_defaults_to_null()
+    {
+        $dto = new ErpDocumentItemDTO();
+        
+        $this->assertNull($dto->price_quantifier);
+    }
+    
+    public function test_price_quantifier_property_accepts_null_value()
+    {
+        $dto = new ErpDocumentItemDTO(price_quantifier: null);
+        
+        $this->assertNull($dto->price_quantifier);
+    }
 }


### PR DESCRIPTION
Adds a new `price_quantifier` property to the ErpDocumentItemDTO class as requested in issue #2.

## Changes
- Added `price_quantifier` as `string|null` property to ErpDocumentItemDTO
- Added comprehensive tests for the new property
- Maintains backward compatibility
- Follows existing code patterns

Closes #2

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional quantifier value in document items.

* **Tests**
  * Introduced tests to verify correct handling of the new quantifier property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->