### PR TITLE
Add PACKAGING_VARIANT reference type and product status

### DIFF
--- a/src/DTOs/ProductDTO.php
+++ b/src/DTOs/ProductDTO.php
@@ -2,6 +2,7 @@
 
 namespace Robodocxs\RobodocxsMiddlewareDtos\DTOs;
 
+use Robodocxs\RobodocxsMiddlewareDtos\Enums\ProductStatus;
 use Robodocxs\RobodocxsMiddlewareDtos\Enums\ProductType;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
@@ -35,5 +36,8 @@ class ProductDTO extends Data
         public ?DataCollection $localized_display_names = null,
 
         public ?string $product_attributes = null,
+
+        /** Sellability of the product in the source ERP; null = unclassified/unknown. */
+        public ?ProductStatus $status = null,
     ) {}
 }

--- a/src/Enums/ProductReferenceType.php
+++ b/src/Enums/ProductReferenceType.php
@@ -6,4 +6,10 @@ enum ProductReferenceType: string
 {
     case ACCESSORY = 'accessory';
     case PRODUCT = 'product';
+
+    /**
+     * A sellable packaging variant of the same base material (e.g. the 100-pack / 1000-pack
+     * articles that a quantity-based packaging resolution can remap a base article onto).
+     */
+    case PACKAGING_VARIANT = 'packaging_variant';
 }

--- a/src/Enums/ProductStatus.php
+++ b/src/Enums/ProductStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Robodocxs\RobodocxsMiddlewareDtos\Enums;
+
+/**
+ * Sellability of a product in the source ERP.
+ *
+ * `null` (an absent value on {@see \Robodocxs\RobodocxsMiddlewareDtos\DTOs\ProductDTO}) means the
+ * middleware does not classify the product — consumers should treat it as usable/unknown rather
+ * than inactive.
+ */
+enum ProductStatus: string
+{
+    case ACTIVE = 'active';
+    case INACTIVE = 'inactive';
+}

--- a/tests/ProductDTOTest.php
+++ b/tests/ProductDTOTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Robodocxs\RobodocxsMiddlewareDtos\DTOs\ProductDTO;
+use Robodocxs\RobodocxsMiddlewareDtos\DTOs\ProductReferenceDTO;
+use Robodocxs\RobodocxsMiddlewareDtos\Enums\ProductReferenceType;
+use Robodocxs\RobodocxsMiddlewareDtos\Enums\ProductStatus;
+use Spatie\LaravelData\DataCollection;
+
+class ProductDTOTest extends TestCase
+{
+    public function test_status_defaults_to_null()
+    {
+        $this->assertNull((new ProductDTO(product_code: 'A'))->status);
+    }
+
+    public function test_status_holds_the_product_status_enum()
+    {
+        $dto = new ProductDTO(product_code: 'A', status: ProductStatus::INACTIVE);
+
+        $this->assertSame(ProductStatus::INACTIVE, $dto->status);
+        $this->assertSame('inactive', $dto->status->value);
+    }
+
+    public function test_product_status_enum_values()
+    {
+        $this->assertSame('active', ProductStatus::ACTIVE->value);
+        $this->assertSame('inactive', ProductStatus::INACTIVE->value);
+        $this->assertSame(ProductStatus::ACTIVE, ProductStatus::tryFrom('active'));
+        $this->assertNull(ProductStatus::tryFrom('unknown'));
+    }
+
+    public function test_packaging_variant_reference_type()
+    {
+        $this->assertSame('packaging_variant', ProductReferenceType::PACKAGING_VARIANT->value);
+        $this->assertSame(ProductReferenceType::PACKAGING_VARIANT, ProductReferenceType::tryFrom('packaging_variant'));
+    }
+
+    public function test_product_references_can_carry_packaging_variants()
+    {
+        $dto = new ProductDTO(
+            product_code: 'BASE',
+            product_references: new DataCollection(ProductReferenceDTO::class, [
+                new ProductReferenceDTO(product_code: 'BASE0100', type: ProductReferenceType::PACKAGING_VARIANT),
+            ]),
+        );
+
+        $reference = $dto->product_references->first();
+
+        $this->assertInstanceOf(ProductReferenceDTO::class, $reference);
+        $this->assertSame(ProductReferenceType::PACKAGING_VARIANT, $reference->type);
+        $this->assertSame('BASE0100', $reference->product_code);
+    }
+}


### PR DESCRIPTION
## What

Two additions consumed by RAMPA's packaging-unit resolution (and reusable by any middleware):

- **`ProductReferenceType::PACKAGING_VARIANT`** — marks a `product_references` entry as a sellable packaging variant of the same base material (e.g. the 100-pack / 1000-pack articles). A quantity-based resolver in robodocxs core uses this to remap a non-sellable base article onto the correct pack.
- **`ProductStatus` enum (`active` / `inactive`) + nullable `ProductDTO::$status`** — the product's sellability in the source ERP. `null` (absent) means the middleware does not classify the product; consumers treat it as usable/unknown rather than inactive. Modelled as an enum to match the package's existing convention (`ProductType`, `ProductReferenceType`); over the wire it serialises to the plain `"active"`/`"inactive"` string.

## Why

RAMPA's Business Central articles encode the packaging unit as a number suffix, with a separate sellable article per pack size and an often non-sellable base. robodocxs needs (a) the sellability flag to know when to remap, and (b) an explicit relation linking a base to its sellable packs. See the robodocxs-core design spec (`docs/superpowers/specs/2026-06-08-rampa-product-recognition-design.md`).

## Tests

Added `tests/ProductDTOTest.php` (status default/assignment, enum values, `PACKAGING_VARIANT` round-trip). Full suite green:

```
OK (19 tests, 48 assertions)
```

## Follow-up

After merge, tag a release (e.g. **2.5.0**) so `robodocxs` and `robodocxs-middleware-rampa` can `composer require` it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)